### PR TITLE
Fix to run only test project

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
 build_script:
 - cmd: dotnet build -c Release
 test_script:
-- cmd: dotnet test
+- cmd: dotnet test ./SgmlTestsCore
 artifacts:
 - path: SgmlReaderCore\bin\Release\*.nupkg
   name: Nuget_Package


### PR DESCRIPTION
Build fails returning 1 if the dotnet test command does not specify only the test project.